### PR TITLE
Split docker-compose-other-apps.yml into gwc and atlas variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ The `docker-compose.override.yml` file adds services to interact with your geOrc
 Feel free to comment out the apps you do not need.
 
 The base docker composition does not include any standalone geowebcache instance, nor the atlas module.
-If you need them, you have to include a complementary docker-compose file at run-time:
+If you need them, you have to include the corresponding complementary docker-compose file at run-time:
 ```
-docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.other-apps.yml up
+docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.gwc.yml -f docker-compose.atlas.yml up
 ```
 
 ## Upgrading

--- a/docker-compose.atlas.yml
+++ b/docker-compose.atlas.yml
@@ -1,0 +1,12 @@
+version: "3"
+
+services:
+  # atlas printing services, eventually queried by the mapfishapp atlas addon
+  atlas:
+    image: georchestra/atlas:latest
+    volumes:
+      - ./config:/etc/georchestra
+    environment:
+      - XMS=512M
+      - XMX=2G
+      - JAVA_OPTIONS=-Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF

--- a/docker-compose.gwc.yml
+++ b/docker-compose.gwc.yml
@@ -16,12 +16,6 @@ services:
     environment:
       - XMS=1G
       - XMX=2G
-
-  # atlas printing services, eventually queried by the mapfishapp atlas addon
-  atlas:
-    image: georchestra/atlas:latest
-    volumes:
-      - ./config:/etc/georchestra
-    environment:
-      - XMS=512M
-      - XMX=2G
+      - JAVA_OPTIONS=-Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF
+#    ports:
+#      - 8080:8080


### PR DESCRIPTION
Make it easier to run either atlas or geowebcache standalone
without running the other.