### PR TITLE
Add docker-compose override file to use a shared gmail account in datafeeder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 .idea/
 *.iml
 *~
+
+# ignore the .env file so we can specify environment variables that are
+# not pushed to github
+.env

--- a/docker-compose.datafeeder.gmail.yml
+++ b/docker-compose.datafeeder.gmail.yml
@@ -1,0 +1,21 @@
+version: "3"
+
+# Use this docker-compose override file in tandem with the default docker-compose.yml file
+# to use the noreply.georchestra.dev@gmail.com test email as administrator email and actually
+# send emails instead of going to the smtp-sink defined in docker-compose.override.yml.
+#
+# i.e.: docker-compose -f docker-compose.yml -f docker-compose.datafeeder.gmail.yml up -d
+#
+# But before doing so, create or edit the .env file and set the SMTP_PASSWORD variable
+# to the actual account password, shared between the georchestra developers.
+services:
+  datafeeder:
+    environment:
+      - smtpPassword=${SMTP_PASSWORD}
+      - smtpHost=smtp.gmail.com
+      - smtpPort=587
+      - smtpUser=noreply.georchestra.dev@gmail.com
+      - smtpAuth=true
+      - smtpTLS=true
+      - administratorEmail=noreply.georchestra.dev@gmail.com
+

--- a/run-datafeeder-gmail.sh
+++ b/run-datafeeder-gmail.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+account="noreply.georchestra.dev@gmail.com"
+
+if [ ! -f ".env" ]; then
+	echo "There's no .env file, create it and set the SMTP_PASSWORD variable to the $account account password"
+	exit 1
+fi
+
+source .env
+
+if [ -z "$SMTP_PASSWORD" ]; then
+	echo "Declare the SMTP_PASSWORD variable in .env with the $account account password"
+	exit 1
+fi
+
+files="-f docker-compose.yml -f docker-compose.override.yml -f docker-compose.datafeeder.gmail.yml"
+
+echo "SMTP_PASSWORD found in .env, running"
+echo "docker-compose $files up -d"
+
+docker-compose $files up -d

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose up -d


### PR DESCRIPTION
The `docker-compose.datafeeder.gmail.yml` file sets up the required
environment variables for datafeeder to use the account
noreply.georchestra.dev@gmail.com to send emails.

The account password is not pushed to github, and must be set in the
`.env` file as `SMTP_PASSWORD=<actual pwd>`.

The `.env` file didn't exist, and has been added to `.gitignore` to
prevent accidental commits sharing the secret.

The `run-datafeeder-gmail.sh` file makes it easier to run the
composition with these settings, checks the env variable is set and runs
the required docker-compose command.