### PR TITLE
datafeeder: use a separate `postgis` container to import uploads

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ volumes:
   extractorapp_extracts:
   geonetwork_datadir:
   datafeeder_uploads:
+  datafeeder_postgis_data:
 
 secrets:
   slapd_password:
@@ -170,6 +171,17 @@ services:
       - ./config:/etc/georchestra
     environment:
       - JAVA_OPTS=-Xms512m -Xmx512m -XX:MaxPermSize=128m -Dgeorchestra.datadir=/etc/georchestra -DPRINT_BASE_URL=pdf
+
+  postgis:
+    # used by datafeeder to ingest uploaded user datasets into
+    image: postgis/postgis:13-3.1-alpine
+    environment:
+      - POSTGRES_DB=datafeeder
+      - POSTGRES_USER=georchestra
+      - POSTGRES_PASSWORD=georchestra
+    volumes:
+      - datafeeder_postgis_data:/var/lib/postgresql/data
+    restart: always
 
   datafeeder:
     image: georchestra/datafeeder:latest


### PR DESCRIPTION
* Fixes https://github.com/georchestra/docker/issues/100
* Depends on https://github.com/georchestra/datadir/pull/217 to be merged to the `docker-master` branch

Define a docker container called `postgis` to use as the target for
 ingesting datafeeder uploaded datasets.

The `config/datafeeder/datafeeder.properties` file shall be
updated accordingly for the internal GeoTools and external GeoServer
connection parameters to hit this separate database.

