### PR TITLE
Geonetwork 4 integration

### DIFF
--- a/GN4.md
+++ b/GN4.md
@@ -1,0 +1,29 @@
+# About
+
+migration to Geonetwork 4 will require several extra services, as the indexes are no longer managed by GeoNetwork itself. This is why you can find back 2 new services in the composition:
+
+* elasticsearch
+* kibana
+
+# Kibana
+
+the `kibana` service is used for dashboarding purposes and is integrated to the Geonetwork admin UI. See in the `Statistics & status / Content statistics` admin menu to access it.
+
+A specific configuration is provided in the `kibana/` subdirectory.
+
+Please note that it will require to load by hand the following file from the kibana admin ui:
+
+https://raw.githubusercontent.com/georchestra/geonetwork/georchestra-gn4-4.x-dev/es/es-dashboards/data/export.ndjson#
+
+
+
+# Elasticsearch
+
+In the current state of the docker composition, no volume is defined, so do not expect persistence of the indexes.
+
+## Disabling disk quota / watermark
+
+If you are running low on disk space, Elastic has a mechanism to pass the index in a read-only mode. You can deactivate this feature by following this guide:
+
+https://techoverflow.net/2019/04/17/how-to-disable-elasticsearch-disk-quota-watermark/
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,13 +140,20 @@ services:
   geonetwork:
     image: georchestra/geonetwork:latest
     depends_on:
-      - ldap
+      - console
       - database
+      - kibana
+      - elasticsearch
     volumes:
       - ./config:/etc/georchestra
       - geonetwork_datadir:/mnt/geonetwork_datadir
     environment:
-      - JAVA_OPTIONS=-Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF
+      - DATA_DIR=/var/lib/geonetwork_data
+      - ES_HOST=elasticsearch
+      - ES_PROTOCOL=http
+      - ES_PORT=9200
+      - KB_URL=http://kibana:5601
+      - JAVA_OPTIONS=-Duser.home=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 -Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF
       - XMS=256M
       - XMX=6G
     restart: always
@@ -195,3 +202,16 @@ services:
     image: georchestra/datafeeder-frontend:21.0-SNAPSHOT
     volumes:
       - ./config:/etc/georchestra
+
+  elasticsearch:
+    image: elasticsearch:7.9.0
+    environment:
+      discovery.type: single-node
+
+  kibana:
+    image: kibana:7.9.0
+    environment:
+      ELASTICSEARCH_HOSTS: http://elasticsearch:9200
+    volumes:
+      - ./kibana/kibana.yml:/usr/share/kibana/config/kibana.yml
+

--- a/kibana/kibana.yml
+++ b/kibana/kibana.yml
@@ -1,0 +1,5 @@
+server.basePath: "/geonetwork/dashboards"
+server.rewriteBasePath: false
+kibana.index: ".dashboards"
+# https://github.com/elastic/kibana/issues/12918
+server.host: "0.0.0.0"


### PR DESCRIPTION
Geonetwork4 integration
    
- update composition to match Geonetwork 4 requirements.
- geonetwork service now depends on console instead of ldap