### PR TITLE
use fullchain instead of the cert only

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -11,7 +11,7 @@ services:
   traefik-me-certificate-downloader:
     image: alpine
     command: sh -c "cd /etc/ssl/traefik
-      && wget traefik.me/cert.pem -O traefik.me.crt
+      && wget traefik.me/fullchain.pem -O traefik.me.crt
       && wget traefik.me/privkey.pem -O traefik.me-key.pem"
     volumes:
       - ./resources/ssl:/etc/ssl/traefik


### PR DESCRIPTION
Sending only the final cert and not the full certs chain breaks some HTTP client.