### PR TITLE
fix trailing slash on well known apps

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -17,7 +17,7 @@ services:
       - ./resources/ssl:/etc/ssl/traefik
 
   georchestra-127-0-1-1.traefik.me:
-    image: traefik:2.4
+    image: traefik:2.9
     depends_on:
       - traefik-me-certificate-downloader
     ports:
@@ -34,8 +34,9 @@ services:
       - "traefik.http.routers.traefik.tls=true"
       - "traefik.http.routers.traefik.rule=Host(`georchestra-127-0-1-1.traefik.me`) && (PathPrefix(`/traefik`) || PathPrefix(`/api`))"
       - "traefik.http.routers.traefik.service=api@internal"
-      - "traefik.http.routers.traefik.middlewares=traefik-strip"
+      - "traefik.http.routers.traefik.middlewares=traefik-strip@docker"
       - "traefik.http.middlewares.traefik-strip.stripprefix.prefixes=/traefik"
+
 
   static:
     image: nginx:stable
@@ -53,28 +54,47 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.proxy.tls=true"
-      - "traefik.http.routers.proxy.priority=100"
+      - "traefik.http.routers.proxy.priority=2"
       - >-
         traefik.http.routers.proxy.rule=Host(`georchestra-127-0-1-1.traefik.me`) && (
-        PathPrefix(`/_static`)
-        || PathPrefix(`/login`)
-        || PathPrefix(`/header`)
-        || PathPrefix(`/extractorapp`)
-        || PathPrefix(`/geoserver`)
-        || PathPrefix(`/console`)
-        || PathPrefix(`/geonetwork`)
-        || PathPrefix(`/analytics`)
-        || PathPrefix(`/mapstore`)
-        || PathPrefix(`/datafeeder`)
-        || PathPrefix(`/import`)
+        PathPrefix(`/_static`) || 
+        PathPrefix(`/login`) || 
+        PathPrefix(`/header`) || 
+        PathPrefix(`/extractorapp`) || 
+        PathPrefix(`/geoserver`) || 
+        PathPrefix(`/console`) || 
+        PathPrefix(`/geonetwork`) || 
+        PathPrefix(`/analytics`) || 
+        PathPrefix(`/mapstore`) || 
+        PathPrefix(`/datafeeder`) || 
+        PathPrefix(`/import`)
         )
       # CORS related. Open everything to the world.
+      - "traefik.http.routers.proxy.middlewares=corsheader@docker"
       - "traefik.http.middlewares.corsheader.headers.accesscontrolallowmethods=GET, HEAD, POST, PUT, DELETE, OPTIONS, PATCH"
       - "traefik.http.middlewares.corsheader.headers.accesscontrolalloworiginlist=*"
       - "traefik.http.middlewares.corsheader.headers.accesscontrolmaxage=1800"
       - "traefik.http.middlewares.corsheader.headers.addvaryheader=true"
       - "traefik.http.middlewares.corsheader.headers.accesscontrolallowcredentials=true"
-      - "traefik.http.routers.proxy.middlewares=corsheader@docker"
+      # Add trailing slash to well-known apps
+      - "traefik.http.routers.traefik-redirect.tls=true"
+      - >-
+        traefik.http.routers.traefik-redirect.rule=Host(`georchestra-127-0-1-1.traefik.me`) && (
+        Path(`/header`) || 
+        Path(`/geoserver`) || 
+        Path(`/console`) || 
+        Path(`/geonetwork`) || 
+        Path(`/analytics`) || 
+        Path(`/mapstore`) || 
+        Path(`/datafeeder`) || 
+        Path(`/import`) || 
+        Path(`/datahub`)
+        )
+      - "traefik.http.routers.traefik-redirect.priority=10"
+      - "traefik.http.routers.traefik-redirect.middlewares=add-trailing-slash@docker"
+      - "traefik.http.middlewares.add-trailing-slash.redirectregex.regex=^https?://(.*)/(.+)"
+      - "traefik.http.middlewares.add-trailing-slash.redirectregex.replacement=https://$${1}/$${2}/"
+      - "traefik.http.middlewares.add-trailing-slash.redirectregex.permanent=true"
 
   cas:
     labels:


### PR DESCRIPTION
With this PR, a permanent redirect is issued on well known paths matching geOrchestra apps (header, geoserver, console, geonetwork, analytics, mapstore, datafeeder, import, datahub)

```
$ curl --head https://georchestra-127-0-1-1.traefik.me/geonetwork
HTTP/2 308 
location: https://georchestra-127-0-1-1.traefik.me/geonetwork/
content-type: text/plain; charset=utf-8
content-length: 18
date: Wed, 08 Feb 2023 10:03:02 GMT
```