### PR TITLE
healthcheck for components + add dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 run-silent:
-	docker-compose up -d
+	docker compose up -d
 
 run:
-	docker-compose up
+	docker compose up
 
 # run without the docker-compose.override.yml
 run-core:
-	docker-compose -f docker-compose.yml up
+	docker compose -f docker-compose.yml up

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ The default docker-compose file contains all geOrchestra modules.
 
 It's recommended to double-check the `docker-compose.yml` and `docker-compose.override.yml` files if you need to comment useless modules (e.g extractor, mapstore,... ).
 
+You need to use the new Compose plugin V2, `docker-compose` (V1) is not supported by default: [https://docs.docker.com/compose/install/linux/](https://docs.docker.com/compose/install/linux/).   
+If you still want to use the old `docker-compose` (V1), you need to remove all the parameters `depends_on` from the files `docker-compose.yml` and `docker-compose.override.yml`.
+
 To run:
 
 ```

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -19,7 +19,10 @@ services:
   georchestra-127-0-1-1.traefik.me:
     image: traefik:2.9
     depends_on:
-      - traefik-me-certificate-downloader
+      traefik-me-certificate-downloader:
+        condition: service_completed_successfully
+    healthcheck:
+      test: traefik healthcheck --ping
     ports:
       - "80:80"
       - "443:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -220,6 +220,8 @@ services:
     depends_on:
       database:
         condition: service_healthy
+      ldap:
+        condition: service_healthy
     volumes:
       - ./config:/etc/georchestra
       - mapstore_extensions:/mnt/mapstore_extensions

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,9 +48,16 @@ services:
 
   proxy:
     image: georchestra/security-proxy:latest
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -f localhost:8080/_static/bootstrap_3.0.0/css/bootstrap-theme.min.css >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
     depends_on:
-      - ldap
-      - database
+      ldap:
+        condition: service_healthy
+      database:
+        condition: service_healthy
     volumes:
       - ./config:/etc/georchestra
     environment:
@@ -61,8 +68,14 @@ services:
 
   cas:
     image: georchestra/cas:latest
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -f localhost:8080/cas/login >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
     depends_on:
-      - ldap
+      ldap:
+        condition: service_healthy
     volumes:
       - ./config:/etc/georchestra
     environment:
@@ -73,6 +86,11 @@ services:
 
   header:
     image: georchestra/header:latest
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -f localhost:8080/header/img/logo.png >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
     volumes:
       - ./config:/etc/georchestra
     environment:
@@ -83,8 +101,16 @@ services:
 
   geoserver:
     image: georchestra/geoserver:latest
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -f localhost:8080/geoserver/gwc/service/wmts?SERVICE=WMTS&REQUEST=GetCapabilities >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
     depends_on:
-      - ldap
+      ldap:
+        condition: service_healthy
+      database:
+        condition: service_healthy
     volumes:
       - ./config:/etc/georchestra
       - geoserver_datadir:/mnt/geoserver_datadir
@@ -99,9 +125,16 @@ services:
 
   console:
     image: georchestra/console:latest
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -f localhost:8080/console/account/new >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
     depends_on:
-      - ldap
-      - database
+      ldap:
+        condition: service_healthy
+      database:
+        condition: service_healthy
     volumes:
       - ./config:/etc/georchestra
     environment:
@@ -112,6 +145,20 @@ services:
 
   geonetwork:
     image: georchestra/geonetwork:latest
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -f localhost:8080/geonetwork/srv/eng/catalog.search >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+    depends_on:
+      console:
+        condition: service_healthy
+      database:
+        condition: service_healthy
+      kibana:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     depends_on:
       - console
       - database
@@ -133,6 +180,11 @@ services:
 
   datahub:
     image: geonetwork/geonetwork-ui-datahub:latest
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -f localhost:80/datahub/ >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
     environment:
       ASSETS_DIRECTORY_OVERRIDE: /etc/georchestra/datahub/assets
       CONFIG_DIRECTORY_OVERRIDE: /etc/georchestra/datahub/conf
@@ -142,8 +194,14 @@ services:
 
   analytics:
     image: georchestra/analytics:latest
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -f localhost:8080/analytics/ >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
     depends_on:
-      - database
+      database:
+        condition: service_healthy
     volumes:
       - ./config:/etc/georchestra
     environment:
@@ -154,8 +212,14 @@ services:
 
   mapstore:
     image: georchestra/mapstore:latest
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -f localhost:8080/mapstore/configs/config.json >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
     depends_on:
-      - database
+      database:
+        condition: service_healthy
     volumes:
       - ./config:/etc/georchestra
       - mapstore_extensions:/mnt/mapstore_extensions
@@ -165,6 +229,11 @@ services:
   postgis:
     # used by datafeeder to ingest uploaded user datasets into
     image: postgis/postgis:13-3.1-alpine
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
     environment:
       - POSTGRES_DB=datafeeder
       - POSTGRES_USER=georchestra
@@ -175,6 +244,16 @@ services:
 
   datafeeder:
     image: georchestra/datafeeder:latest
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -f localhost:8080/datafeeder >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+    depends_on:
+      database:
+        condition: service_healthy
+      postgis:
+        condition: service_healthy
     volumes:
       - ./config:/etc/georchestra
       - datafeeder_uploads:/tmp/datafeeder
@@ -183,16 +262,29 @@ services:
 
   import:
     image: georchestra/datafeeder-frontend:latest
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider localhost:80/ >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
     volumes:
       - ./config:/etc/georchestra
 
   elasticsearch:
     image: elasticsearch:7.9.0
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -f localhost:9200/_cat/health >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
     environment:
       discovery.type: single-node
 
   kibana:
     image: kibana:7.9.0
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
     environment:
       ELASTICSEARCH_HOSTS: http://elasticsearch:9200
     volumes:

--- a/resources/traefik.yml
+++ b/resources/traefik.yml
@@ -29,3 +29,5 @@ api:
 
 log:
   level: INFO
+
+ping: {}


### PR DESCRIPTION
This PR adds dependencies on the different services from docker-compose file.

Essentially, each component, that depend on another component(s), **will** start only if the dependent component(s) are healthy/working fine.

Before that, all the components would start at the same time and some of them would error out due to some database that is not reachable yet. See here for a real world example: https://github.com/georchestra/docker/issues/136

The changes require using the new Compose plugin V2: https://docs.docker.com/compose/install/linux/

Fixes #136