### PR TITLE
gs - mounts jetty-env.xml into the webapp's classpath

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,6 +163,7 @@ services:
       - geoserver_geodata:/mnt/geoserver_geodata
       - geoserver_tiles:/mnt/geoserver_tiles
       - geoserver_native_libs:/mnt/geoserver_native_libs
+      - ./config/geoserver/jetty-env.xml:/var/lib/jetty/webapps/geoserver/WEB-INF/jetty-env.xml
     environment:
       - JAVA_OPTIONS=-Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF
       - XMS=256M


### PR DESCRIPTION
This to be able to resolve the JNDI resources. On the geOrchestra helm chart, this is managed by an initContainer.

Will probably also require:
https://github.com/georchestra/datadir/pull/292