### PR TITLE
route requests having a login parameter to the security-proxy

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -77,6 +77,7 @@ services:
         || PathPrefix(`/mapstore`)
         || PathPrefix(`/ogc-api-records`)
         || PathPrefix(`/_static`)
+        || Query(`login=`)
         )
       - "traefik.http.services.proxy.loadbalancer.server.port=8080"
       # CORS related. Open everything to the world.


### PR DESCRIPTION
Using the composition, `/?login` is currently not handled by the security-proxy.
This is yet required for the login link on the home page to work as expected.