### PR TITLE
Fix infinite redirection when path root contains query params

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -56,13 +56,13 @@ services:
       - "traefik.http.routers.static.rule=Host(`georchestra-127-0-1-1.traefik.me`)"
       - "traefik.http.routers.static.priority=1"
 
-  proxy:
+  gateway:
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.proxy.tls=true"
-      - "traefik.http.routers.proxy.priority=2"
+      - "traefik.http.routers.gateway.tls=true"
+      - "traefik.http.routers.gateway.priority=2"
       - >-
-        traefik.http.routers.proxy.rule=Host(`georchestra-127-0-1-1.traefik.me`) && (
+        traefik.http.routers.gateway.rule=Host(`georchestra-127-0-1-1.traefik.me`) && (
         PathPrefix(`/analytics`)
         || PathPrefix(`/datafeeder`)
         || PathPrefix(`/datahub`)
@@ -78,15 +78,15 @@ services:
         || PathPrefix(`/ogc-api-records`)
         || PathPrefix(`/_static`)
         )
-      - "traefik.http.services.proxy.loadbalancer.server.port=8080"
+      - "traefik.http.services.gateway.loadbalancer.server.port=8080"
       # CORS related. Open everything to the world.
-      - "traefik.http.routers.proxy.middlewares=corsheader@docker"
+      - "traefik.http.routers.gateway.middlewares=corsheader@docker"
       - "traefik.http.middlewares.corsheader.headers.accesscontrolallowmethods=GET, HEAD, POST, PUT, DELETE, OPTIONS, PATCH"
       - "traefik.http.middlewares.corsheader.headers.accesscontrolalloworiginlist=*"
       - "traefik.http.middlewares.corsheader.headers.accesscontrolmaxage=1800"
       - "traefik.http.middlewares.corsheader.headers.addvaryheader=true"
       - "traefik.http.middlewares.corsheader.headers.accesscontrolallowcredentials=true"
-      - "traefik.http.routers.proxy.middlewares=corsheader@docker,static-errors-middleware@docker"
+      - "traefik.http.routers.gateway.middlewares=corsheader@docker,static-errors-middleware@docker"
       # handle downstream errors
       - "traefik.http.middlewares.static-errors-middleware.errors.status=500-599"
       - "traefik.http.middlewares.static-errors-middleware.errors.service=static-docker@docker"
@@ -112,11 +112,6 @@ services:
       - "traefik.http.middlewares.add-trailing-slash.redirectregex.replacement=https://$${1}/$${2}/"
       - "traefik.http.middlewares.add-trailing-slash.redirectregex.permanent=false"
 
-  cas:
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.cas.tls=true"
-      - "traefik.http.routers.cas.rule=Host(`georchestra-127-0-1-1.traefik.me`) && PathPrefix(`/cas`)"
 
   smtp:
     image: camptocamp/smtp-sink:latest

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -108,7 +108,7 @@ services:
         )
       - "traefik.http.routers.traefik-redirect.priority=10"
       - "traefik.http.routers.traefik-redirect.middlewares=add-trailing-slash@docker"
-      - "traefik.http.middlewares.add-trailing-slash.redirectregex.regex=^https?://(.*)/(.+)"
+      - "traefik.http.middlewares.add-trailing-slash.redirectregex.regex=^https?://^[^?]+$/(.+)"
       - "traefik.http.middlewares.add-trailing-slash.redirectregex.replacement=https://$${1}/$${2}/"
       - "traefik.http.middlewares.add-trailing-slash.redirectregex.permanent=false"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,8 @@ services:
     depends_on:
       envsubst:
         condition: service_completed_successfully
+    ports:
+      - "389:389"
     secrets:
       - slapd_password
       - geoserver_privileged_user_passwd
@@ -78,53 +80,20 @@ services:
       - ldap_config:/etc/ldap
     restart: always
 
-  proxy:
-    image: georchestra/security-proxy:latest
-    healthcheck:
-      test: ["CMD-SHELL", "curl -s -f http://localhost:8080/_static/bootstrap_3.0.0/css/bootstrap-theme.min.css >/dev/null || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 10
+  gateway:
+    image: georchestra/gateway:latest
     depends_on:
-      ldap:
-        condition: service_healthy
-      database:
-        condition: service_healthy
+      - database
     volumes:
       - georchestra_datadir:/etc/georchestra
     environment:
-      - JAVA_OPTIONS=-Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF
-      - XMS=256M
-      - XMX=1G
+      - JAVA_OPTS=-Dgeorchestra.datadir=/etc/georchestra
     env_file:
       - .envs-common
       - .envs-ldap
       - .envs-hosts
       - .envs-database-georchestra
-    restart: always
-
-  cas:
-    image: georchestra/cas:latest
-    healthcheck:
-      test: ["CMD-SHELL", "curl -s -f http://localhost:8080/cas/login >/dev/null || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 10
-    depends_on:
-      ldap:
-        condition: service_healthy
-    volumes:
-      - georchestra_datadir:/etc/georchestra
-    environment:
-      - JAVA_OPTIONS=-Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF
-      - XMS=256M
-      - XMX=1G
-    env_file:
-      - .envs-common
-      - .envs-ldap
-      - .envs-database-georchestra
-    restart: always
-
+  
   header:
     image: georchestra/header:latest
     healthcheck:
@@ -335,6 +304,8 @@ services:
       interval: 30s
       timeout: 10s
       retries: 10
+    ports:
+      - "8080:80"
     depends_on:
       envsubst:
         condition: service_completed_successfully


### PR DESCRIPTION
to fix infinite redirection when path root contains query params,  traefik redirection rules in docker-compose.override.yml has to be updated. A new regex formula is used to check is query param exist or not