### PR TITLE
Upgrade kibana version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -359,7 +359,7 @@ services:
       ES_JAVA_OPTS: -Xms512m -Xmx512m
 
   kibana:
-    image: kibana:7.9.0
+    image: docker.elastic.co/kibana/kibana:7.15.1
     depends_on:
       elasticsearch:
         condition: service_healthy


### PR DESCRIPTION
The kibana version should be the same as ES for compatibility reasons.

Ideally this should be backported to 23.0.