### PR TITLE
Remove jetty env copy logic in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,7 +163,6 @@ services:
       - geoserver_geodata:/mnt/geoserver_geodata
       - geoserver_tiles:/mnt/geoserver_tiles
       - geoserver_native_libs:/mnt/geoserver_native_libs
-      - ./config/geoserver/jetty-env.xml:/var/lib/jetty/webapps/geoserver/WEB-INF/jetty-env.xml
     environment:
       - JAVA_OPTIONS=-Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF
       - XMS=256M


### PR DESCRIPTION
The logic is moved to https://github.com/georchestra/georchestra/pull/4143

Backport from https://github.com/georchestra/docker/pull/265