### PR TITLE
Added port so that the service-name of static is independent

### DIFF
--- a/.envs-common
+++ b/.envs-common
@@ -1,4 +1,0 @@
-# envs-common
-FQDN=georchestra-127-0-1-1.traefik.me
-SMTPHOST=smtp
-SMTPPORT=25

--- a/README.md
+++ b/README.md
@@ -73,9 +73,7 @@ These emails can be read on https://georchestra-127-0-1-1.traefik.me/webmail/ (w
 The current FQDN `georchestra-127-0-1-1.traefik.me` resolves to 127.0.1.1, thanks to [traefik.me](https://traefik.me/) which provides wildcard DNS for any IP address.
 
 To change it:
- * Rename the traefik service in the `docker-compose.override.yml` file to match the new domain
- * Modify the three `traefik.http.routers.*.rule` in the `docker-compose.override.yml` file
- * Update the FQDN variable in [.envs-common](.envs-common) file (hint: grep for `georchestra-127-0-1-1.traefik.me`)
+ * Update the FQDN variable in [.env](.env) file
  * Put a valid SSL certificate in the `resources/ssl` folder and declare it in the `resources/traefik-config.yml` file
 
 ## Notes
@@ -112,7 +110,7 @@ To upgrade, we recommend you to:
 This docker composition supports environment variables, if you need to customize something it might be in the different environment variables files.
 
 Here is the list of these files:
-- [.envs-common](.envs-common) 
+- [.env](.env) 
 - [.envs-database-datafeeder](.envs-database-datafeeder)
 - [.envs-database-georchestra](.envs-database-georchestra)
 - [.envs-hosts](.envs-hosts)

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -19,8 +19,8 @@ services:
     volumes:
       - ./resources/ssl:/etc/ssl/traefik
 
-  georchestra-127-0-1-1.traefik.me:
-    image: traefik:2.9
+  traefik:
+    image: traefik:2.11
     depends_on:
       traefik-me-certificate-downloader:
         condition: service_completed_successfully
@@ -38,11 +38,10 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.traefik.tls=true"
-      - "traefik.http.routers.traefik.rule=Host(`georchestra-127-0-1-1.traefik.me`) && (PathPrefix(`/traefik`) || PathPrefix(`/api`))"
+      - "traefik.http.routers.traefik.rule=Host(`${FQDN}`) && (PathPrefix(`/traefik`) || PathPrefix(`/api`))"
       - "traefik.http.routers.traefik.service=api@internal"
       - "traefik.http.routers.traefik.middlewares=traefik-strip@docker"
       - "traefik.http.middlewares.traefik-strip.stripprefix.prefixes=/traefik"
-
 
   static:
     image: nginx:stable
@@ -53,9 +52,8 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.static.tls=true"
-      - "traefik.http.routers.static.rule=Host(`georchestra-127-0-1-1.traefik.me`)"
+      - "traefik.http.routers.static.rule=Host(`${FQDN}`)"
       - "traefik.http.routers.static.priority=1"
-      - "traefik.http.services.static.loadbalancer.server.port=80"
 
   proxy:
     labels:
@@ -63,7 +61,7 @@ services:
       - "traefik.http.routers.proxy.tls=true"
       - "traefik.http.routers.proxy.priority=2"
       - >-
-        traefik.http.routers.proxy.rule=Host(`georchestra-127-0-1-1.traefik.me`) && (
+        traefik.http.routers.proxy.rule=Host(`${FQDN}`) && (
         PathPrefix(`/analytics`)
         || PathPrefix(`/datafeeder`)
         || PathPrefix(`/datahub`)
@@ -92,12 +90,12 @@ services:
       - "traefik.http.routers.proxy.middlewares=corsheader@docker,static-errors-middleware@docker"
       # handle downstream errors
       - "traefik.http.middlewares.static-errors-middleware.errors.status=500-599"
-      - "traefik.http.middlewares.static-errors-middleware.errors.service=static@docker"
+      - "traefik.http.middlewares.static-errors-middleware.errors.service=static-docker@docker"
       - "traefik.http.middlewares.static-errors-middleware.errors.query=/errors/50x.html"
       # Add trailing slash to well-known apps
       - "traefik.http.routers.traefik-redirect.tls=true"
       - >-
-        traefik.http.routers.traefik-redirect.rule=Host(`georchestra-127-0-1-1.traefik.me`) && (
+        traefik.http.routers.traefik-redirect.rule=Host(`${FQDN}`) && (
         Path(`/analytics`)
         || Path(`/datafeeder`)
         || Path(`/datahub`)
@@ -119,7 +117,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.cas.tls=true"
-      - "traefik.http.routers.cas.rule=Host(`georchestra-127-0-1-1.traefik.me`) && PathPrefix(`/cas`)"
+      - "traefik.http.routers.cas.rule=Host(`${FQDN}`) && PathPrefix(`/cas`)"
 
   smtp:
     image: camptocamp/smtp-sink:latest
@@ -143,7 +141,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.webmail.tls=true"
-      - "traefik.http.routers.webmail.rule=Host(`georchestra-127-0-1-1.traefik.me`) && PathPrefix(`/webmail`)"
+      - "traefik.http.routers.webmail.rule=Host(`${FQDN}`) && PathPrefix(`/webmail`)"
     restart: always
 
   ssh:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -55,6 +55,7 @@ services:
       - "traefik.http.routers.static.tls=true"
       - "traefik.http.routers.static.rule=Host(`georchestra-127-0-1-1.traefik.me`)"
       - "traefik.http.routers.static.priority=1"
+      - "traefik.http.services.static.loadbalancer.server.port=80"
 
   proxy:
     labels:
@@ -91,7 +92,7 @@ services:
       - "traefik.http.routers.proxy.middlewares=corsheader@docker,static-errors-middleware@docker"
       # handle downstream errors
       - "traefik.http.middlewares.static-errors-middleware.errors.status=500-599"
-      - "traefik.http.middlewares.static-errors-middleware.errors.service=static-docker@docker"
+      - "traefik.http.middlewares.static-errors-middleware.errors.service=static@docker"
       - "traefik.http.middlewares.static-errors-middleware.errors.query=/errors/50x.html"
       # Add trailing slash to well-known apps
       - "traefik.http.routers.traefik-redirect.tls=true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - DEBUG=yes
       - SUBST_FILES=/etc/georchestra/security-proxy/targets-mapping.properties /etc/georchestra/datafeeder/frontend-config.json /etc/georchestra/datafeeder/metadata_* /etc/georchestra/geonetwork/microservices/ogc-api-records/config.yml
     env_file:
-      - .envs-common
+      - .env
       - .envs-hosts
     volumes:
       - georchestra_datadir:/etc/georchestra
@@ -98,7 +98,7 @@ services:
       - XMS=256M
       - XMX=1G
     env_file:
-      - .envs-common
+      - .env
       - .envs-ldap
       - .envs-hosts
       - .envs-database-georchestra
@@ -121,7 +121,7 @@ services:
       - XMS=256M
       - XMX=1G
     env_file:
-      - .envs-common
+      - .env
       - .envs-ldap
       - .envs-database-georchestra
     restart: always
@@ -143,7 +143,7 @@ services:
       - XMS=256M
       - XMX=512M
     env_file:
-      - .envs-common
+      - .env
     restart: always
 
   geoserver:
@@ -193,7 +193,7 @@ services:
       - XMS=256M
       - XMX=1G
     env_file:
-      - .envs-common
+      - .env
       - .envs-ldap
       - .envs-database-georchestra
       - .envs-hosts
@@ -324,7 +324,7 @@ services:
       # You can set a higher loglevel this way: (ref. https://docs.spring.io/spring-boot/docs/2.1.13.RELEASE/reference/html/boot-features-logging.html#boot-features-custom-log-levels)
       - LOGGING_LEVEL_ORG_GEORCHESTRA_DATAFEEDER=INFO
     env_file:
-      - .envs-common
+      - .env
       - .envs-hosts
       - .envs-database-georchestra
       - .envs-database-datafeeder


### PR DESCRIPTION
So traefik sees the 'static' service as static-\<directory\>@docker and that how it is addressed. But you want to have it directory independant. There is no direct way to name/label your service , but according to [this](https://stackoverflow.com/questions/66158478/how-to-set-traefik-2-4-service-name-in-docker-compose-labels) you can fix this by e.g. 
```
labels:
  - traefik.http.services.<<name_of_service>>.loadbalancer.server.port=80
```
So, that's what we do here.
It fixes https://github.com/georchestra/docker/issues/214