### PR TITLE
Added port so that the service-name of static is independent

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -55,6 +55,7 @@ services:
       - "traefik.http.routers.static.tls=true"
       - "traefik.http.routers.static.rule=Host(`georchestra-127-0-1-1.traefik.me`)"
       - "traefik.http.routers.static.priority=1"
+      - "traefik.http.services.static.loadbalancer.server.port=80"
 
   proxy:
     labels:
@@ -91,7 +92,7 @@ services:
       - "traefik.http.routers.proxy.middlewares=corsheader@docker,static-errors-middleware@docker"
       # handle downstream errors
       - "traefik.http.middlewares.static-errors-middleware.errors.status=500-599"
-      - "traefik.http.middlewares.static-errors-middleware.errors.service=static-docker@docker"
+      - "traefik.http.middlewares.static-errors-middleware.errors.service=static@docker"
       - "traefik.http.middlewares.static-errors-middleware.errors.query=/errors/50x.html"
       # Add trailing slash to well-known apps
       - "traefik.http.routers.traefik-redirect.tls=true"


### PR DESCRIPTION
So traefik sees the 'static' service as static-\<directory\>@docker and that how it is addressed. But you want to have it directory independent. There is no direct way to name/label your service , but according to [this](https://stackoverflow.com/questions/66158478/how-to-set-traefik-2-4-service-name-in-docker-compose-labels) you can fix this by e.g.

labels:
  - traefik.http.services.<<name_of_service>>.loadbalancer.server.port=80

So, that's what we do here.
It fixes #214

(N.B Split up from https://github.com/georchestra/docker/pull/278)