### PR TITLE
Limit Rbmq disk limit and update import healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -407,6 +407,7 @@ services:
       - .envs-rabbitmq
     environment:
       - RABBITMQ_LOGS=-
+      - RABBITMQ_DISK_FREE_ABSOLUTE_LIMIT=1GB
     volumes:
       - 'rabbitmq_data:/bitnami/rabbitmq/mnesia'
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -327,7 +327,7 @@ services:
   import:
     image: georchestra/datafeeder-frontend:latest
     healthcheck:
-      test: ["CMD-SHELL", "curl -s -f http://localhost:80/ >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://127.0.0.1:80/ >/dev/null || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -327,7 +327,7 @@ services:
   import:
     image: georchestra/datafeeder-frontend:latest
     healthcheck:
-      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:80/ >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "curl -s -f http://localhost:80/ >/dev/null || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 10


### PR DESCRIPTION
Limit rbmq size to avoid this error on container starting : 
```
Error:
Free disk space alarm on node rabbit@localhost
```
See https://github.com/georchestra/docker/issues/306

And update datafeeder import healthcheck to make it work.