### PR TITLE
Data-api in docker comp

### DIFF
--- a/.envs-hosts
+++ b/.envs-hosts
@@ -15,6 +15,7 @@ KB_PORT=5601
 ES_HOST=elasticsearch
 ES_PORT=9200
 RABBITMQ_HOST=rabbitmq
+DATA_API_HOST=data-api
 
 # needed for geonetwork entrypoint DO NOT REMOVE
 CONSOLE_URL=http://${CONSOLE_HOST}:8080

--- a/docker-compose.data-api.yml
+++ b/docker-compose.data-api.yml
@@ -1,0 +1,26 @@
+version: "3.1"
+
+services:
+  data-api:
+    image: georchestra/data-api:1.3.0
+    #    healthcheck:
+    #      test: [ "CMD-SHELL", "curl -s -f http://localhost:8080/data/ogcapi >/dev/null || exit 1" ]
+    #      interval: 30s
+    #      timeout: 10s
+    #      retries: 10
+    depends_on:
+      database:
+        condition: service_healthy
+    volumes:
+      - georchestra_datadir:/etc/georchestra
+    environment:
+      SPRING_PROFILES_ACTIVE: postgis
+      LOGGING_LEVEL_COM_CAMPTOCAMP: DEBUG
+      LOGGING_LEVEL_ORG_GEOTOOLS: DEBUG
+      SERVER_SERVLET_CONTEXT_PATH: /data
+      POSTGRES_HOST: postgis
+      POSTGRES_PORT: 5432
+      POSTGRES_DB: datafeeder
+      POSTGRES_USER: georchestra
+      POSTGRES_PASSWORD: georchestra
+      JAVA_TOOL_OPTIONS: "-Ddataapi.configdir=/etc/georchestra"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
 version: "3.1"
 
+include:
+  - docker-compose.data-api.yml
+
 volumes:
   postgresql_data:
   ldap_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -314,7 +314,7 @@ services:
       - georchestra_datadir:/etc/georchestra
       - datafeeder_uploads:/tmp/datafeeder
     environment:
-      - JAVA_OPTS=-Xms512m -Xmx512m
+      - JAVA_OPTS=-Xms512m -Xmx512m -Dspring.profiles.active=georchestra,data-api-schemas -Dspring.config.additional-location=file:/etc/georchestra/data-api/application.yaml
       # You can set a higher loglevel this way: (ref. https://docs.spring.io/spring-boot/docs/2.1.13.RELEASE/reference/html/boot-features-logging.html#boot-features-custom-log-levels)
       - LOGGING_LEVEL_ORG_GEORCHESTRA_DATAFEEDER=INFO
     env_file:
@@ -412,4 +412,3 @@ services:
       - 'rabbitmq_data:/bitnami/rabbitmq/mnesia'
     restart: always
 
-      


### PR DESCRIPTION
This PR adds data api to docker comp plugged to datafeeder. 

It allows to test data ingestion : 
- Tests report : https://www.georchestra.org/e2e-tests
- Github : https://github.com/georchestra/e2e-tests