### PR TITLE
Fix defunct processes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,7 @@ services:
   geoserver:
     image: georchestra/geoserver:latest
     healthcheck:
-      test: ["CMD-SHELL", "curl -s -f http://localhost:8080/geoserver/gwc/service/wmts?SERVICE=WMTS&REQUEST=GetCapabilities >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "curl -s -f 'http://localhost:8080/geoserver/gwc/service/wmts?SERVICE=WMTS&REQUEST=GetCapabilities' >/dev/null || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,7 @@ services:
   geoserver:
     image: georchestra/geoserver:latest
     healthcheck:
-      test: ["CMD-SHELL", "curl -s -f 'http://localhost:8080/geoserver/gwc/service/wmts?SERVICE=WMTS&REQUEST=GetCapabilities' >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "curl -s -f 'http://localhost:8080/geoserver/ows?SERVICE=WMS&LAYERS=geor:public_layer&FORMAT=image/png&VERSION=1.3.0&SLD_VERSION=1.1.0&REQUEST=GetMap&CRS=EPSG:3857&BBOX=-20820223,-20820223,20820223,20820223&WIDTH=10&HEIGHT=10' >/dev/null || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 10


### PR DESCRIPTION
the problem of `defunct` (zombie) process is a bad escapement of the `&` in the url to be accessed by `curl` in an healthcheck with url parameters. This PR escapes the url by adding 2 little `''` characters, which caused way more headhaches to find than expected.