### PR TITLE
Fix RabbitMQ image for 24.0: use bitnamilegacy/rabbitmq:3.12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -399,7 +399,7 @@ services:
     restart: always
 
   rabbitmq:
-    image: docker.io/bitnami/rabbitmq:3.12
+    image: docker.io/bitnamilegacy/rabbitmq:3.12
     healthcheck:
       test: rabbitmq-diagnostics -q ping && rabbitmq-diagnostics -q check_local_alarms
       interval: 60s


### PR DESCRIPTION
## Problem

On branch `24.0`, deploying geOrchestra fails because the RabbitMQ image `bitnami/rabbitmq:3.12.14` no longer exists:

manifest for bitnami/rabbitmq:3.12.14 not found: manifest unknown

## Cause

Bitnami migrated older RabbitMQ images to a legacy repository:
- Old repository: `bitnami/rabbitmq`
- Legacy repository: `bitnamilegacy/rabbitmq`

As a result, the tag `3.12.14` is no longer available in the original `bitnami` repository.

## Solution

This PR updates the Docker Compose configuration to use the legacy image:

```yaml
rabbitmq:
  image: docker.io/bitnamilegacy/rabbitmq:3.12
```
This allows the deployment to succeed on branch 24.0 without breaking backward compatibility.
