### PR TITLE
Update rabbitmq image to 3.13

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -401,7 +401,7 @@ services:
     restart: always
 
   rabbitmq:
-    image: docker.io/bitnami/rabbitmq:3.12
+    image: rabbitmq:3.13
     healthcheck:
       test: rabbitmq-diagnostics -q ping && rabbitmq-diagnostics -q check_local_alarms
       interval: 60s
@@ -413,6 +413,5 @@ services:
       - RABBITMQ_LOGS=-
       - RABBITMQ_DISK_FREE_ABSOLUTE_LIMIT=1GB
     volumes:
-      - 'rabbitmq_data:/bitnami/rabbitmq/mnesia'
+      - 'rabbitmq_data:/var/lib/rabbitmq/mnesia'
     restart: always
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ volumes:
   datafeeder_postgis_data:
   esdata:
   georchestra_datadir:
-  rabbitmq_data:
+  rabbit_data:
 
 secrets:
   slapd_password:
@@ -413,5 +413,5 @@ services:
       - RABBITMQ_LOGS=-
       - RABBITMQ_DISK_FREE_ABSOLUTE_LIMIT=1GB
     volumes:
-      - 'rabbitmq_data:/var/lib/rabbitmq/mnesia'
+      - 'rabbit_data:/var/lib/rabbitmq/mnesia'
     restart: always


### PR DESCRIPTION
Closes #356 

As bitnami images aren't available anymore, we now use rabbitmq official images