### PR TITLE
Update mapstore for geOrchestra 25

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -261,7 +261,7 @@ services:
     restart: always
 
   mapstore:
-    image: georchestra/mapstore:2024.02.00-geOrchestra
+    image: georchestra/mapstore:2024.02.00-geOrchestra-headerConfig-6abf34
     healthcheck:
       test: ["CMD-SHELL", "curl -s -f http://localhost:8080/mapstore/configs/config.json >/dev/null || exit 1"]
       interval: 30s


### PR DESCRIPTION
Mapstore 2024 has two fixes in this new version. 
- Header config file was not correctly used
- Some computers with recent kernels weren't able to run mapstore image (deprecation of cgroup 1). 