### PR TITLE
[24.0] - Backport commits from pr-358

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ volumes:
   datafeeder_postgis_data:
   esdata:
   georchestra_datadir:
-  rabbitmq_data:
+  rabbit_data:
 
 secrets:
   slapd_password:
@@ -411,5 +411,5 @@ services:
       - RABBITMQ_LOGS=-
       - RABBITMQ_DISK_FREE_ABSOLUTE_LIMIT=1GB
     volumes:
-      - 'rabbitmq_data:/var/lib/rabbitmq/mnesia'
+      - 'rabbit_data:/var/lib/rabbitmq/mnesia'
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -399,7 +399,7 @@ services:
     restart: always
 
   rabbitmq:
-    image: docker.io/bitnamilegacy/rabbitmq:3.12
+    image: rabbitmq:3.13
     healthcheck:
       test: rabbitmq-diagnostics -q ping && rabbitmq-diagnostics -q check_local_alarms
       interval: 60s
@@ -411,7 +411,5 @@ services:
       - RABBITMQ_LOGS=-
       - RABBITMQ_DISK_FREE_ABSOLUTE_LIMIT=1GB
     volumes:
-      - 'rabbitmq_data:/bitnami/rabbitmq/mnesia'
+      - 'rabbitmq_data:/var/lib/rabbitmq/mnesia'
     restart: always
-
-


### PR DESCRIPTION
Next to https://github.com/georchestra/docker/pull/355.
This PR backport commits to use stable rabbitmq image v3.13 (instead bitnamilegacy).