### PR TITLE
Missing env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,6 +156,7 @@ services:
       - JAVA_OPTIONS=-Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF
       - XMS=256M
       - XMX=8G
+      - GEOSERVER_FILESYSTEM_SANDBOX=/mnt/geoserver_geodata
 
     env_file:
       - .envs-database-georchestra

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -411,6 +411,10 @@ services:
       SPRING_CONFIG_LOCATION: file:///etc/georchestra/geonetwork/microservices/ogc-api-records/config.yml
       SPRING_PROFILES_ACTIVE: standalone
       JAVA_OPTS: -Dfile.encoding=UTF-8
+    env_file:
+      - .envs-elastic
+      - .envs-database-georchestra
+      - .envs-common
     volumes:
       - georchestra_datadir:/etc/georchestra
     restart: always


### PR DESCRIPTION
# geoserver
Uploading a file using the geoserver api returns Caused by:
java.lang.IllegalStateException: Could not create file.

georchestra 25 introduce sandboxing by default:
https://docs.geoserver.org/stable/en/user/security/sandbox.html
Consequently, the variable GEOSERVER_FILESYSTEM_SANDBOX should be set.

# ogc-api-records
branch 25 of datadir introduces variables in
geonetwork/microservices/ogc-api-records/config.yml, instead of
hardcoded values in branch 24:
PGHOST
PGPORT
PGDATABASE
PGUSER
PGPASSWORD
FQDN
ES_HOST
ES_PORT
ES_USERNAME
ES_PASSWORD
Consequently, they need to be define in ogc-api-records service


I don't know how to add the label backport-25.0.